### PR TITLE
Fix to figure captions

### DIFF
--- a/uma-core.xml
+++ b/uma-core.xml
@@ -150,9 +150,7 @@
         <t><xref target="UMA-roles" /> shows the communications among the
         roles at a high level.</t>
 
-        <figure align="center" anchor="UMA-roles">
-          <preamble>Roles and Communications</preamble>
-
+        <figure align="center" anchor="UMA-roles" title="Roles and Communications">
           <artwork><![CDATA[                                        +------------------+
                                         |     resource     |
        +- - manage (out of scope) - - - |       owner      |
@@ -413,8 +411,7 @@
         specifications of messaging flows and options that correspond to all
         possible success and failure paths.</t>
 
-        <figure anchor="protocol-flow">
-          <preamble>Protocol Flow Summary</preamble>
+        <figure anchor="protocol-flow" title="Protocol Flow Summary">
 
           <artwork><![CDATA[resource resource        authorization             client requesting
  owner    server             server                   |      party

--- a/util/rfc2629.xslt
+++ b/util/rfc2629.xslt
@@ -3946,7 +3946,7 @@
           <xsl:choose>
             <xsl:when test="position() = 2">
               <tr>
-                <td class="left kantara">Contributors:</td>
+                <td class="left kantara">Authors:</td>
                 <td class="left kantara"><xsl:value-of select="$contributor"/></td>
               </tr>
             </xsl:when>


### PR DESCRIPTION
Fixes two captions to show "Figure 1: xxxxx”, and appear that way in the TOC. 