### PR TITLE
Minor typo claim_tokens -> claim_token

### DIFF
--- a/oauth-uma-grant.xml
+++ b/oauth-uma-grant.xml
@@ -1548,7 +1548,7 @@ Host: photoz.example.com
         <section title="Registry Contents">
           <t>
             <list style="symbols">
-              <t>Parameter name: <spanx style="verb">claim_tokens</spanx></t>
+              <t>Parameter name: <spanx style="verb">claim_token</spanx></t>
 
               <t>Parameter usage location: client request, token endpoint</t>
 


### PR DESCRIPTION
I noticed that `claim_tokens` is referenced in [Section 7.3.1 of oauth-uma-grant-2.0-04](https://docs.kantarainitiative.org/uma/ed/oauth-uma-grant-2.0-04.html#rfc.section.7.3.1), but isn't referenced anywhere else.  I assumed it was actually a reference to `claim_token` referenced in [Section 3.3.1](https://docs.kantarainitiative.org/uma/ed/oauth-uma-grant-2.0-04.html#rfc.section.3.3.1).