### PR TITLE
Fix typos in oauth-uma-grant.xml

### DIFF
--- a/oauth-uma-grant.xml
+++ b/oauth-uma-grant.xml
@@ -153,7 +153,7 @@
         and its communications with the authorization server are included for
         completeness, although policy condition setting is outside the scope
         of this specification and communications among the other four entities
-        are asynchrjonous with respect to resource owner actions. Further,
+        are asynchronous with respect to resource owner actions. Further,
         although both claims pushing and interactive claims gathering are
         shown, both might not typically be used in one scenario.</t>
 
@@ -1423,7 +1423,7 @@ Host: photoz.example.com
             authentication was performed.</t>
 
             <t>Require claims to have a high degree of freshness in order for
-            them to satify policy conditions.</t>
+            them to satisfy policy conditions.</t>
 
             <t>Tighten time-to-live strategies around RPTs and their
             associated permissions (see <xref target="ttl" />).</t>


### PR DESCRIPTION
Hi! I was reading the spec[^1]  and I came across two typos:

- asynchrjonous -> asynchronous <sup>(fixes #360)</sup>
- satify -> satisfy

This MR fixes both.

[^1]: Thank you for your hard work, by the way, much appreciated!